### PR TITLE
feat: add extractor CLI overrides

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -1,3 +1,15 @@
+"""GUI launcher for the OCR/translation pipeline.
+
+When using ``extractor.py`` outside the GUI, the script now supports
+additional command-line flags:
+
+  --roi y1,y2,x1,x2        Provide subtitle region to skip interactive selection.
+  --scene_threshold FLOAT  Override scene detection sensitivity.
+  --change_threshold FLOAT Override pixel-change threshold for subtitle changes.
+
+These options allow batch or headless usage of the extractor component.
+"""
+
 import tkinter as tk
 from tkinter import filedialog, messagebox, scrolledtext, ttk
 import subprocess


### PR DESCRIPTION
## Summary
- add optional ROI and threshold overrides to extractor CLI
- document extractor command-line flags in launcher script

## Testing
- `python -m py_compile extractor.py launcher.py`
- `python extractor.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6895726ab3688328b87974fc89083f68